### PR TITLE
Upgrade to Koa 2 

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,27 +11,26 @@ npm install --save koa-jsend
 In your [koa](http://koajs.com) app.
 
 ```javascript
-var koa = require('koa')
+var Koa = require('koa')
   , jsend = require('koa-jsend')
   ;
 
-var app = koa();
+var app = new Koa();
 
 app.use(jsend());
 ```
 
 ## API
 
-Instead of using `this.body=` to send JSON responses, use one of the functions in `this`.
-Where `this` is the koa context, `ctx`.
+Instead of using `ctx.body=` to send JSON responses, use one of the functions in `ctx`.
 
 ### `ctx.success(data)`
 
 * __data__: _Optional_ response data.
 
 ```javascript
-app.use(function *(){
-  this.success({
+app.use(async function (ctx, next){
+  ctx.success({
     name: 'Samora',
     sex: 'Male',
     nationality: 'Ghanaian'
@@ -54,8 +53,8 @@ app.use(function *(){
 * __errors__: _Required_ error(s) data.
 
 ```javascript
-app.use(function *(){
-  this.fail({
+app.use(async function (ctx, next){
+  ctx.fail({
     name: 'Name is required.'
   });
 });
@@ -76,8 +75,8 @@ app.use(function *(){
 * __code__: _Optional_ error code.
 
 ```javascript
-app.use(function *(){
-  this.error('Something went wrong.', null, 8);
+app.use(async function (ctx, next){
+  ctx.error('Something went wrong.', null, 8);
 });
 
 // JSON response
@@ -98,8 +97,8 @@ Sends a `ctx.error` response if `err` is passed.
 * __code__: _Optional_
 
 ```javascript
-app.use(function *(){
-  this.jsend(null, {
+app.use(async function (ctx, next){
+  ctx.jsend(null, {
     name: 'Samora',
     sex: 'Male',
     nationality: 'Ghanaian'
@@ -119,8 +118,8 @@ app.use(function *(){
 
 
 ```javascript
-app.use(function *(){
-  this.jsend(Error('Something went wrong.'));
+app.use(async function (ctx, next){
+  ctx.jsend(Error('Something went wrong.'));
 });
 
 // JSON response

--- a/index.js
+++ b/index.js
@@ -3,31 +3,28 @@
 // Based on JSend (http://labs.omniti.com/labs/jsend)
 
 module.exports = function (){
-  return function *(next){
-    // koa context
-    var that = this;
-    
-
+  return async function(ctx, next){
+  
     /**
      * Augment koa context to have success response.
      *
      * @param {object} data
      */
-    that.success = function (data){
-      that.body = {
+    ctx.success = function (data){
+      ctx.body = {
         status: 'success',
         data: data || null
       };
     };
-
+    
 
     /**
      * Augment koa context to have `fail` response.
      *
      * @param {object} errors
      */
-    that.fail = function (errors){
-      that.body = {
+    ctx.fail = function (errors){
+      ctx.body = {
         status: 'fail',
         data: errors
       };
@@ -41,26 +38,26 @@ module.exports = function (){
      * @param {object} data optional
      * @param {string/number} code optional
      */
-    that.error = function (message, data, code){
+    ctx.error = function (message, data, code){
 
       if (!(message instanceof Error) && (typeof message !== 'string'))
         throw new Error('Invalid message. Must be error object or string.');
 
-      that.body = {
+      ctx.body = {
         status: 'error'
       };
 
       if (message instanceof Error)
-        that.body.message = message.message;
+        ctx.body.message = message.message;
 
       if (typeof message === 'string')
-        that.body.message = message;
+        ctx.body.message = message;
 
       if (data && typeof(data) === 'object') 
-        that.body.data = data;
+        ctx.body.data = data;
 
       if (code && (typeof(code) === 'string' || typeof(code) === 'number')) 
-        that.body.code = code;
+        ctx.body.code = code;
     };
 
 
@@ -71,13 +68,13 @@ module.exports = function (){
      * @param {object} data
      * @param {string/number} code
      */
-    that.jsend = function (err, data, code){
+    ctx.jsend = function (err, data, code){
       if (err)
-        return that.error(err, data, code);
+        return ctx.error(err, data, code);
 
-      that.success(data);
+      ctx.success(data);
     };
 
-    yield next;
+    await next();
   };
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koa-jsend",
-  "version": "0.1.0",
+  "version": "2.0.0",
   "description": "Simple and structured application level JSON responses for Koa based on JSend specification.",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Hey @samora,

I updated the jSend middleware to work with koa2. Many koa-middlewares maintain a master and 2.x branch. I think it would be fine to just merge into master and release as `2.0.0` to mark a breaking change. Otherwise you could make 2.x master and keep the 1.x branch in case you are planning to support it in the future. 

What do you think? 